### PR TITLE
Add Redis service and conf

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,8 @@ POSTGRES_DB='n8n'
 # n8n
 N8N_ENCRYPTION_KEY='super-secret-key'
 N8N_USER_MANAGEMENT_JWT_SECRET='even-more-secret'
+
+# Redis
+REDIS_HOST='redis'
+REDIS_PORT='6379'
+REDIS_PASSWORD='password'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ See [INFO.md](INFO.md) for upstream details.
 - **Ollama**: Cross-platform LLM runner
 - **Qdrant**: Vector database for AI applications
 - **PostgreSQL**: Relational database for data storage
+- **Redis**: In-memory data structure store, used for caching and session management
+- **Supabase**: Open-source alternative to Firebase, used for real-time data sync and storage
+
+
+## 🛠 Project Workflow
+
+1. **Setup**: The Docker Compose file initializes all necessary services.
+2. **Data Ingestion**: Use n8n workflows to load data into Qdrant or Supabase.
+3. **AI Processing**: Leverage Ollama for local LLM inference within n8n workflows.
+4. **Workflow Creation**: Build custom AI agents and RAG systems using n8n's visual editor.
+5. **Integration**: Connect your AI workflows with external services and APIs.
+6. **Execution**: Run your workflows on-demand or on a schedule within the self-hosted environment.
+
 ## 🚀 Connecting to localhost services
 
 When integrating with other services running on your local machine (outside of the Docker network), use the special DNS name `host.docker.internal` instead of `localhost`. This allows containers to communicate with services on your host machine.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ volumes:
   postgres_storage:
   ollama_storage:
   qdrant_storage:
+  redis_storage:
 
 networks:
   demo:
@@ -100,6 +101,22 @@ services:
       - 6333:6333
     volumes:
       - qdrant_storage:/qdrant/storage
+
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    networks: ['n8n-ai-network']
+    restart: unless-stopped
+    environment:
+      - REDIS_HOST
+      - REDIS_PORT
+      - REDIS_PASSWORD
+    ports:
+      - 6379:6379
+    volumes:
+      - redis_storage:/data
+      - ./redis/redis.conf:/usr/local/etc/redis/redis.conf
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
 
   ollama-cpu:
     profiles: ["cpu"]

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -1,0 +1,74 @@
+# Redis configuration file
+
+# Network
+bind 0.0.0.0
+port 6379
+protected-mode yes
+
+# General
+daemonize no
+pidfile /var/run/redis/redis-server.pid
+loglevel notice
+logfile ""
+
+# Snapshotting
+save 900 1
+save 300 10
+save 60 10000
+stop-writes-on-bgsave-error yes
+rdbcompression yes
+rdbchecksum yes
+dbfilename dump.rdb
+dir /data
+
+# Replication
+replica-serve-stale-data yes
+replica-read-only yes
+
+# Security
+requirepass password
+
+# Limits
+maxclients 10000
+
+# Memory management
+maxmemory 256mb
+maxmemory-policy allkeys-lru
+
+# Append only mode
+appendonly no
+appendfilename "appendonly.aof"
+appendfsync everysec
+
+# Lua scripting
+lua-time-limit 5000
+
+# Slow log
+slowlog-log-slower-than 10000
+slowlog-max-len 128
+
+# Latency monitor
+latency-monitor-threshold 0
+
+# Event notification
+notify-keyspace-events ""
+
+# Advanced config
+hash-max-ziplist-entries 512
+hash-max-ziplist-value 64
+list-max-ziplist-size -2
+list-compress-depth 0
+set-max-intset-entries 512
+zset-max-ziplist-entries 128
+zset-max-ziplist-value 64
+hll-sparse-max-bytes 3000
+stream-node-max-bytes 4096
+stream-node-max-entries 100
+activerehashing yes
+client-output-buffer-limit normal 0 0 0
+client-output-buffer-limit replica 256mb 64mb 60
+client-output-buffer-limit pubsub 32mb 8mb 60
+hz 10
+dynamic-hz yes
+aof-rewrite-incremental-fsync yes
+rdb-save-incremental-fsync yes


### PR DESCRIPTION
Description:

This pull request adds a Redis service to the docker compose file. Also adds the Redis configuration file with
various settings for performance, security, and memory management.

Changes:

 • Docker compose:
    • Adds Redis service to docker compose

 • Redis configuration:
    • Set network bind address to 0.0.0.0.
    • Enabled protected mode.
    • Configured snapshotting settings for automatic saves.
    • Set replication settings for read-only replicas.
    • Secured the Redis instance with a password.
    • Limited the maximum number of clients and memory usage.

Testing:

 • Verify that the N8n workflow runs successfully after updating the configuration file.
 • Test the Redis instance to ensure it is functioning correctly, including snapshotting, replication, and security settings.
