### PR TITLE
Feat: Update Ollama for Deepseek R1 model

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ x-init-ollama: &init-ollama
     - OLLAMA_HOST=ollama:11434
   command:
     - "-c"
-    - "sleep 3; ollama pull llama3.2"
+    - "sleep 3; ollama pull deepseek-r1:1.5b"
 
 services:
   postgres:


### PR DESCRIPTION
### 🚀 What does this PR do?

This PR updates `docker-compose.yml` so that Ollama container uses Deepseek R1 1.5B model

- Updates compose to pull Deepseek R1 model

